### PR TITLE
Bug fix in the calculation of the rorS

### DIFF
--- a/R/rorS.R
+++ b/R/rorS.R
@@ -8,7 +8,7 @@ function(data, annot, do.mapping=FALSE, mapping, verbose=FALSE) {
   ## ROR-S
   rs.unscaled <- rs <- rsrisk <- rep(NA, nrow(data))
   names(rs.unscaled) <- names(rs) <- names(rsrisk) <- rownames(data)
-  rst <- 0.05 * sbts$cor[ , "Basal"] + 0.12 * sbts$cor[ , "Her2"] - 0.34 * sbts$cor[ , "LumA"] + 0.23 * sbts$cor[ , "LumA"]
+  rst <- 0.05 * sbts$cor[ , "Basal"] + 0.12 * sbts$cor[ , "Her2"] - 0.34 * sbts$cor[ , "LumA"] + 0.23 * sbts$cor[ , "LumB"]
   rs.unscaled[names(rst)] <- rst
   ## rescale between 0 and 100
   rs <- (rs.unscaled - quantile(rs.unscaled, probs=0.025, na.rm=TRUE)) / (quantile(rs.unscaled, probs=0.975, na.rm=TRUE) - quantile(rs.unscaled, probs=0.025, na.rm=TRUE)) * 100


### PR DESCRIPTION
I'm not 100% sure, but I guess, that the second "LumA" in the line:
 rst <- 0.05 \* sbts$cor[ , "Basal"] + 0.12 \* sbts$cor[ , "Her2"] - 0.34 \* sbts$cor[ , "LumA"] + 0.23 \* sbts$cor[ , "LumA"]
should be LumB.
